### PR TITLE
Align Mayfly to the accepted interface of Boost.Process.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ INCLUDEDIR ?= $(PREFIX)/include
 test: ./tests/test
 
 ./tests/test: $(TESTOBJ) $(LIBRARY)
-	$(LD) $(CXXFLAGS) $(LDFLAGS) $(TESTOBJ) -o $@ $(LIBRARIES) -lboost_system -lboost_iostreams -lboost_program_options -lboost_filesystem -ldl -pthread
+	$(LD) $(CXXFLAGS) $(LDFLAGS) $(TESTOBJ) -o $@ $(LIBRARIES) -lboost_system -lboost_program_options -lboost_filesystem -ldl -pthread
 
 install: $(LIBRARY) # $(EXECUTABLE)
 #	@cp $(EXECUTABLE) $(DESTDIR)$(BINDIR)/$(EXECUTABLE)

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ closely integrated with Despayre, the Reaver Project's build system.
 
 ## Supported compilers
 
-Currently supported compilers include GCC 5.1+ and Clang 3.7+, both with libstdc++
-and libc++, and with Boost 1.60.0+. It probably also works on lower versions, but
-no such compatibility will be checked and maintained.
+Currently supported compilers include GCC 6.1+ and Clang 3.9+, both with libstdc++
+and libc++, and with Boost 1.64.0+. 
 
 CI status can be checked on [Reaver Project's TeamCity server](http://ci.reaver-project.org/viewType.html?buildTypeId=mayfly_Tests&guest=1).


### PR DESCRIPTION
Until now I've been using the old version of Boost.Process, from before
it was rewritten to pass the Boost review, but now that it made it into
Boost, it's time to use the new version.

I *could* ifdef all this, but I'm not going to, and hence - Reaver
Project projects now require Boost 1.64+.